### PR TITLE
Fix PDF formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,6 +130,7 @@ function downloadPDF() {
   const element = document.createElement("div");
   element.style.direction = "rtl";
   element.style.padding = "20px";
+  element.style.whiteSpace = "pre-line";
   element.innerText = document.getElementById("result").innerText;
 
   const opt = {


### PR DESCRIPTION
## Summary
- ensure exported PDF preserves line breaks by adding `whiteSpace: pre-line` when generating the div for html2pdf

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848a55ef2b88331a227728f51b39b93