### PR TITLE
Improve empty-result check before PDF

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,11 +147,16 @@ function shareWhatsApp() {
 }
 
 function downloadPDF() {
+  const text = document.getElementById('result').innerText.trim();
+  if (!text) {
+    alert(isEnglish ? 'Please generate a recipe first.' : 'אנא צור מתכון קודם.');
+    return;
+  }
   const element = document.createElement("div");
   element.style.direction = isEnglish ? "ltr" : "rtl";
   element.style.padding = "20px";
   element.style.whiteSpace = "pre-line";
-  element.innerText = document.getElementById("result").innerText;
+  element.innerText = text;
 
   const opt = {
     margin: 0.5,


### PR DESCRIPTION
## Summary
- validate trimmed recipe text when downloading PDF
- show an alert if no recipe text is available

## Testing
- `bash -lc 'git status --short'`

------
https://chatgpt.com/codex/tasks/task_e_6848abc4be288331972a53c6248dae4c